### PR TITLE
(refactor) Replace all $rootScope.destinationPermalink w/sessionStorage

### DIFF
--- a/app/client/app/favorites/favorites.js
+++ b/app/client/app/favorites/favorites.js
@@ -30,9 +30,7 @@ angular.module('travel.favorites', [])
 
   $scope.selectGroup = function(groupInfo) {
     $rootScope.currentGroup = groupInfo;
-    $rootScope.destinationPermalink = Util.transToPermalink(groupInfo.destination);
-    var dest = $rootScope.destinationPermalink;
-    $window.sessionStorage.setItem('knowhere', dest);
+    $window.sessionStorage.setItem('knowhere', Util.transToPermalink(groupInfo.destination));
     $state.go('favorites');
   };
 

--- a/app/client/app/itinerary/itinerary.js
+++ b/app/client/app/itinerary/itinerary.js
@@ -31,9 +31,7 @@ angular.module('travel.itinerary', [])
 
   $scope.selectGroup = function(groupInfo) {
     $rootScope.currentGroup = groupInfo;
-    $rootScope.destinationPermalink = Util.transToPermalink(groupInfo.destination);
-    var dest = $rootScope.destinationPermalink;
-    $window.sessionStorage.setItem('knowhere', dest);
+    $window.sessionStorage.setItem('knowhere', Util.transToPermalink(groupInfo.destination));
     $state.go('itinerary');
   };
 

--- a/app/client/app/landing/landing.js
+++ b/app/client/app/landing/landing.js
@@ -5,22 +5,21 @@ angular.module('travel.landing', [])
   $scope.data = {};
 
   $scope.sendData = function() {
-    $rootScope.destinationPermalink = Util.transToPermalink($scope.data.destination);
-    var dest = $rootScope.destinationPermalink;
-    $window.sessionStorage.setItem('knowhere', dest);
+    $window.sessionStorage.setItem('knowhere', Util.transToPermalink($scope.data.destination));
     $rootScope.currentUser = $rootScope.currentUser || "anonymous";
+
     if ($scope.data.group === undefined) {
       data = {
         groupName: "anonymous",
         userInfo: $rootScope.currentUser,
-        destination: $rootScope.destinationPermalink
+        destination: $window.sessionStorage.getItem('knowhere')
       };
       Groups.createGroup(data);
       Groups.getGroups("anonymous")
       .then(function(groupsInfo){
         groupsInfo.forEach(function(group){
           if (group.title === "anonymous") {
-            group.destination = $rootScope.destinationPermalink; 
+            group.destination = $window.sessionStorage.getItem('knowhere'); 
             $rootScope.currentGroup = group;
           }
         });
@@ -29,7 +28,7 @@ angular.module('travel.landing', [])
       data = {
         groupName: $scope.data.group,
         userInfo: $rootScope.currentUser,
-        destination: $rootScope.destinationPermalink
+        destination: $window.sessionStorage.getItem('knowhere')
       };
       Groups.createGroup(data);
       Groups.getGroups($rootScope.currentUser)

--- a/app/client/app/results/results.js
+++ b/app/client/app/results/results.js
@@ -26,9 +26,7 @@ angular.module('travel.results', [])
 
   $scope.selectGroup = function(groupInfo) {
     $rootScope.currentGroup = groupInfo;
-    $rootScope.destinationPermalink = Util.transToPermalink(groupInfo.destination);
-    var dest = $rootScope.destinationPermalink;
-    $window.sessionStorage.setItem('knowhere', dest);
+    $window.sessionStorage.setItem('knowhere', Util.transToPermalink(groupInfo.destination));
     $state.go('results');
   };
 


### PR DESCRIPTION
the whole `var destination = $window.sessionStorage.getItem('knowhere') || $rootScope.destinationPermalink;` thing etc seemed redundant. everywhere 'knowhere' sessionStorage is used, $rootScope.destinationPermalink is also used, and vice versa